### PR TITLE
Patch effects on quickload

### DIFF
--- a/debug.lua
+++ b/debug.lua
@@ -17,14 +17,12 @@ local effectCount = 0
 local sortedEffectList = {}
 
 function debugInit()
-	effectCount = GetEffectCount()
-
+	debugSetupEffectsList()
+	
 	if testThisEffect ~= "" then
 		chaosTimer = chaosEffects.effects[testThisEffect].effectDuration
 		currentTime = chaosTimer * 0.98
 	end
-
-	sortedEffectList = SortEffectsTable(effectCount)
 end
 
 function debugTick()
@@ -36,8 +34,18 @@ function debugTick()
 		textboxClass_tick()
 		checkMouseScroll()
 	end
+	
+	if #sortedEffectList == 0 and debugMenuEnabled then
+		debugSetupEffectsList()
+	end
 
 	checkDebugMenuToggles()
+end
+
+function debugSetupEffectsList()
+	effectCount = GetEffectCount()
+	
+	sortedEffectList = SortEffectsTable(effectCount)
 end
 
 function debugDraw()
@@ -48,6 +56,8 @@ function debugDraw()
 	if debugMenuEnabled then
 		drawDebugMenu()
 		drawEffectList()
+		listScreenHeight = UiMiddle() - 20
+		listScreenMaxScroll = (effectCount * 30 + 2) - listScreenHeight + 15
 	end
 end
 
@@ -58,12 +68,9 @@ function checkDebugMenuToggles()
 
 	if InputDown("ctrl") and InputPressed("h") then
 		debugMenuEnabled = not debugMenuEnabled
-
+		
 		if not debugMenuEnabled then
 			mouseActive = false
-		else
-			listScreenHeight = UiMiddle() - 20
-			listScreenMaxScroll = (effectCount * 30 + 2) - listScreenHeight + 15
 		end
 	end
 end
@@ -184,8 +191,7 @@ function drawEffectList()
 			UiColor(1, 1, 1, 1)
 
 			local i = 0
-
-
+			
 			for key, uid in ipairs(sortedEffectList) do
 				local effect = chaosEffects.effects[uid]
 				UiPush()

--- a/effects.lua
+++ b/effects.lua
@@ -48,7 +48,7 @@ function chaosSpritesInit()
 			for i=1, #currentEffect.effectSprites do
 				local currentSpriteData = currentEffect.effectSprites[i]
 				
-				if type(currentSpriteData) == "table" then
+				if type(currentSpriteData) == "string" then
 					local handle = 0
 
 					if loadedSprites[currentSpriteData] ~= nil then

--- a/effects.lua
+++ b/effects.lua
@@ -1,14 +1,25 @@
 #include "utils.lua"
 
-function chaosSFXInit()
+function chaosSFXInit(quickloaded)
 	local loadedSFX = {loops = {}, regular = {}}
 
 	for key, value in ipairs(chaosEffects.effectKeys) do
 		local currentEffect = chaosEffects.effects[value]
-
+		
+		if currentEffect.effectSFXBackup == nil then
+			currentEffect.effectSFXBackup = {}
+		end
+		
 		if #currentEffect.effectSFX > 0 then
 			for i=1, #currentEffect.effectSFX do
-				local soundData =  currentEffect.effectSFX[i]
+				local soundData = nil
+				
+				if quickloaded then
+					soundData = currentEffect.effectSFXBackup[i]
+				else
+					soundData = currentEffect.effectSFX[i]
+				end
+				
 				local soundPath = soundData["soundPath"]
 				local isLoop = soundData["isLoop"]
 				local handle = nil
@@ -32,20 +43,33 @@ function chaosSFXInit()
 				end
 
 				currentEffect.effectSFX[i] = handle
+				currentEffect.effectSFXBackup[i] = soundData
 			end
 		end
 	end
 end
 
-function chaosSpritesInit()
+function chaosSpritesInit(quickloaded)
+	quickloaded = quickloaded or false
+	
 	local loadedSprites = {}
 
 	for key, value in ipairs(chaosEffects.effectKeys) do
 		local currentEffect = chaosEffects.effects[value]
+		
+		if currentEffect.effectSpritesBackup == nil then
+			currentEffect.effectSpritesBackup = {}
+		end
 
 		if #currentEffect.effectSprites > 0 then
 			for i=1, #currentEffect.effectSprites do
-				local currentSpriteData = currentEffect.effectSprites[i]
+				local currentSpriteData = nil
+				
+				if quickloaded then
+					currentSpriteData = currentEffect.effectSpritesBackup[i]
+				else
+					currentSpriteData = currentEffect.effectSprites[i]
+				end
 
 				local handle = 0
 
@@ -57,6 +81,7 @@ function chaosSpritesInit()
 				end
 
 				currentEffect.effectSprites[i] = handle
+				currentEffect.effectSpritesBackup[i] = currentSpriteData
 			end
 		end
 	end
@@ -75,9 +100,9 @@ function chaosKeysInit()
 	table.remove(chaosEffects.activeEffects, 1)
 end
 
-function loadChaosEffectData()
-	chaosSFXInit()
-	chaosSpritesInit()
+function loadChaosEffectData(quickloaded)
+	chaosSFXInit(quickloaded)
+	chaosSpritesInit(quickloaded)
 end
 
 function removeDisabledEffectKeys()

--- a/effects.lua
+++ b/effects.lua
@@ -1,87 +1,65 @@
 #include "utils.lua"
 
-function chaosSFXInit(quickloaded)
+function chaosSFXInit()
 	local loadedSFX = {loops = {}, regular = {}}
 
 	for key, value in ipairs(chaosEffects.effectKeys) do
 		local currentEffect = chaosEffects.effects[value]
 		
-		if currentEffect.effectSFXBackup == nil then
-			currentEffect.effectSFXBackup = {}
-		end
-		
 		if #currentEffect.effectSFX > 0 then
 			for i=1, #currentEffect.effectSFX do
-				local soundData = nil
+				local soundData = currentEffect.effectSFX[i]
 				
-				if quickloaded then
-					soundData = currentEffect.effectSFXBackup[i]
-				else
-					soundData = currentEffect.effectSFX[i]
-				end
-				
-				local soundPath = soundData["soundPath"]
-				local isLoop = soundData["isLoop"]
-				local handle = nil
+				if type(soundData) == "table" then
+					local soundPath = soundData["soundPath"]
+					local isLoop = soundData["isLoop"]
+					local handle = 0
 
-				local handle = 0
-
-				if isLoop then
-					if loadedSFX.loops[soundPath] ~= nil then
-						handle = loadedSFX.loops[soundPath]
+					if isLoop then
+						if loadedSFX.loops[soundPath] ~= nil then
+							handle = loadedSFX.loops[soundPath]
+						else
+							handle = LoadLoop(soundPath)
+							loadedSFX.loops[soundPath] = handle
+						end
 					else
-						handle = LoadLoop(soundPath)
-						loadedSFX.loops[soundPath] = handle
+						if loadedSFX.regular[soundPath] ~= nil then
+							handle = loadedSFX.regular[soundPath]
+						else
+							handle = LoadSound(soundPath)
+							loadedSFX.regular[soundPath] = handle
+						end
 					end
-				else
-					if loadedSFX.regular[soundPath] ~= nil then
-						handle = loadedSFX.regular[soundPath]
-					else
-						handle = LoadSound(soundPath)
-						loadedSFX.regular[soundPath] = handle
-					end
+					
+					currentEffect.effectSFX[i] = handle
 				end
-
-				currentEffect.effectSFX[i] = handle
-				currentEffect.effectSFXBackup[i] = soundData
 			end
 		end
 	end
 end
 
-function chaosSpritesInit(quickloaded)
-	quickloaded = quickloaded or false
-	
+function chaosSpritesInit()
 	local loadedSprites = {}
 
 	for key, value in ipairs(chaosEffects.effectKeys) do
 		local currentEffect = chaosEffects.effects[value]
 		
-		if currentEffect.effectSpritesBackup == nil then
-			currentEffect.effectSpritesBackup = {}
-		end
-
 		if #currentEffect.effectSprites > 0 then
 			for i=1, #currentEffect.effectSprites do
-				local currentSpriteData = nil
+				local currentSpriteData = currentEffect.effectSprites[i]
 				
-				if quickloaded then
-					currentSpriteData = currentEffect.effectSpritesBackup[i]
-				else
-					currentSpriteData = currentEffect.effectSprites[i]
+				if type(currentSpriteData) == "table" then
+					local handle = 0
+
+					if loadedSprites[currentSpriteData] ~= nil then
+						handle = loadedSprites[currentSpriteData]
+					else
+						handle = LoadSprite(currentSpriteData)
+						loadedSprites[currentSpriteData] = handle
+					end
+					
+					currentEffect.effectSprites[i] = handle
 				end
-
-				local handle = 0
-
-				if loadedSprites[currentSpriteData] ~= nil then
-					handle = loadedSprites[currentSpriteData]
-				else
-					handle = LoadSprite(currentSpriteData)
-					loadedSprites[currentSpriteData] = handle
-				end
-
-				currentEffect.effectSprites[i] = handle
-				currentEffect.effectSpritesBackup[i] = currentSpriteData
 			end
 		end
 	end
@@ -100,9 +78,9 @@ function chaosKeysInit()
 	table.remove(chaosEffects.activeEffects, 1)
 end
 
-function loadChaosEffectData(quickloaded)
-	chaosSFXInit(quickloaded)
-	chaosSpritesInit(quickloaded)
+function loadChaosEffectData()
+	chaosSFXInit()
+	chaosSpritesInit()
 end
 
 function removeDisabledEffectKeys()

--- a/main.lua
+++ b/main.lua
@@ -12,12 +12,17 @@ currentTime = 0
 timerPaused = false
 chaosPaused = false
 hasTheGameReloaded = false
+
+-- Inside the init() these changes don't get backed up.
+-- Here they do. Allowing quickloading to be available.
+saveFileInit()
+
+removeDisabledEffectKeys()
+loadChaosEffectData()
+
 UpdateQuickloadPatch()
 
 function init()
-	saveFileInit()
-	removeDisabledEffectKeys()
-	loadChaosEffectData()
 	debugInit()
 
 	UpdateQuickloadPatch()

--- a/main.lua
+++ b/main.lua
@@ -101,6 +101,10 @@ function GetChaosTimeStep()
 end
 
 function tick(dt)
+	if hasQuickloaded() then
+		loadChaosEffectData(true)
+	end
+
 	quickloadTick()
 
 	-- Failsafe

--- a/main.lua
+++ b/main.lua
@@ -101,10 +101,6 @@ function GetChaosTimeStep()
 end
 
 function tick(dt)
-	if hasQuickloaded() then
-		loadChaosEffectData(true)
-	end
-
 	quickloadTick()
 
 	-- Failsafe
@@ -161,7 +157,7 @@ function drawTimer()
 	UiPop()
 
 	UiPush()
-		if hasTheGameReloaded then
+		if chaosUnavailable() then
 			UiColor(1, 0.25, 0.25)
 		else
 			UiColor(0.25, 0.25, 1)

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,4 @@
+#include "quickload.lua"
 #include "effects.lua"
 #include "utils.lua"
 #include "debug.lua"
@@ -11,18 +12,18 @@ currentTime = 0
 timerPaused = false
 chaosPaused = false
 hasTheGameReloaded = false
+UpdateQuickloadPatch()
 
 function init()
 	saveFileInit()
-
 	removeDisabledEffectKeys()
-
 	loadChaosEffectData()
-
 	debugInit()
+
+	UpdateQuickloadPatch()
 end
 
-function gameReloaded()
+function chaosUnavailable()
 	return chaosEffects.effectTemplate.onEffectStart == nil
 end
 
@@ -100,23 +101,20 @@ function GetChaosTimeStep()
 end
 
 function tick(dt)
-	if not hasTheGameReloaded and gameReloaded() then
+	quickloadTick()
+
+	-- Failsafe
+	if chaosUnavailable() then
 		chaosEffects.activeEffects = {}
 
 		local warningEffect = getCopyOfEffect("nothing")
-		warningEffect.name = "Currently the Chaos mod\ndoes not support quick loading.\nThe mod is disabled until restarting\nthe level."
-
+		warningEffect.name = "An error occurred while loading\nthe effects from a quick load.\nPlease restart the level to\nkeep using Chaos mod."
 		warningEffect.onEffectStart = function() end
 		warningEffect.onEffectTick = function() end
 		warningEffect.onEffectEnd = function() end
 
 		triggerEffect(warningEffect)
-
-		hasTheGameReloaded = true
 		currentTime = chaosTimer
-	end
-
-	if hasTheGameReloaded then
 		return
 	end
 

--- a/quickload.lua
+++ b/quickload.lua
@@ -1,0 +1,44 @@
+-- Workaround from UMF: https://github.com/Thomasims/TeardownUMF/blob/master/core/default_hooks.lua#L57-L100
+
+local saved = {}
+QL = { i = function() end }
+
+local function hasfunction( t, bck )
+	if bck[t] then
+		return
+	end
+	bck[t] = true
+	for k, v in pairs( t ) do
+		if type( v ) == "function" then
+			return true
+		end
+		if type( v ) == "table" and hasfunction( v, bck ) then
+			return true
+		end
+	end
+end
+
+function UpdateQuickloadPatch()
+	for k, v in pairs( _G ) do
+		if k ~= "_G" and type( v ) == "table" and hasfunction( v, {} ) then
+			saved[k] = v
+		end
+	end
+end
+
+local function hasQuickloaded()
+	return QL.i == nil
+end
+
+local quickloadfix = function()
+	for k, v in pairs( saved ) do
+		_G[k] = v
+	end
+end
+
+function quickloadTick()
+	if hasQuickloaded() then
+		quickloadfix()
+	end
+end
+

--- a/quickload.lua
+++ b/quickload.lua
@@ -26,7 +26,7 @@ function UpdateQuickloadPatch()
 	end
 end
 
-local function hasQuickloaded()
+function hasQuickloaded()
 	return QL.i == nil
 end
 

--- a/quickload.lua
+++ b/quickload.lua
@@ -26,7 +26,7 @@ function UpdateQuickloadPatch()
 	end
 end
 
-function hasQuickloaded()
+local function hasQuickloaded()
 	return QL.i == nil
 end
 


### PR DESCRIPTION
This patches the effects from quickloading, thus making the mod available even after quickloading.
This workaround was from [TeardownUMF](https://github.com/Thomasims/TeardownUMF/blob/master/core/default_hooks.lua#L57-L100).